### PR TITLE
Fix/gui

### DIFF
--- a/src/main/java/tech/inudev/profundus/profundusLib/gui/Gui.java
+++ b/src/main/java/tech/inudev/profundus/profundusLib/gui/Gui.java
@@ -217,7 +217,9 @@ public class Gui implements Listener {
      */
     public ItemStack cloneItemStack(int x, int y) {
         PosMenuItem pos = menuItems.stream().filter(v -> v.x() == x && v.y() == y).findFirst().orElse(null);
-        return pos != null ? pos.menuItem().getIcon().clone() : null;
+        return pos != null && pos.menuItem().getIcon() != null
+                ? pos.menuItem().getIcon().clone()
+                : null;
     }
 
     /**


### PR DESCRIPTION
draggableなmenuItemでは空欄の場合にiconがnullになるので、
`cloneItemStack`のiconがnullでないかをチェックするように修正しました。

ご確認よろしくお願いします。